### PR TITLE
fix(docs): disable git metadata on Vercel builds

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,6 +13,7 @@ import path from 'path';
 
 // Guard webpack config for Nx compatibility
 const isNxBuild = process.env.NX_BUILD === 'true' || process.env.NX_WORKSPACE_ROOT !== undefined;
+const enableGitLastUpdate = !process.env.VERCEL;
 
 // Plugin configuration - only include webpack plugin when NOT using Nx
 const plugins: any[] = [];
@@ -122,8 +123,8 @@ const config: Config = {
           routeBasePath: '/', // Docs at root
           // Enable GitHub editing
           editUrl: 'https://github.com/lanonasis/docs-lanonasis-com/edit/main/',
-          showLastUpdateTime: true,
-          showLastUpdateAuthor: true,
+          showLastUpdateTime: enableGitLastUpdate,
+          showLastUpdateAuthor: enableGitLastUpdate,
         },
         blog: false, // Disable blog - docs only
         theme: {


### PR DESCRIPTION
## Summary
- disable Docusaurus git last-update metadata when building on Vercel
- keep last-update metadata enabled for local builds

## Why
The Vercel build environment is not a full git checkout, so Docusaurus fails when it tries to read git history for doc metadata. This blocked production deploys and left `docs.lanonasis.com` serving the previous artifact set.

## Validation
- local docs build previously passes
- production deploy failure traced to git metadata lookup on Vercel
- this patch removes that hosted-only failure path