### PR TITLE
docs: sync CLI version marker to 3.11.2

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -5,7 +5,7 @@ sidebar_label: CLI Reference
 
 # LanOnasis CLI Reference
 
-Complete reference for the `@lanonasis/cli` v<!-- AUTO:CLI_VERSION -->3.11.1<!-- /AUTO --> - Professional CLI for Memory as a Service (MaaS).
+Complete reference for the `@lanonasis/cli` v<!-- AUTO:CLI_VERSION -->3.11.2<!-- /AUTO --> - Professional CLI for Memory as a Service (MaaS).
 
 ## Installation
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -27,7 +27,7 @@ npm install -g @lanonasis/cli
 onasis --version
 ```
 
-The current documented CLI is <!-- AUTO:CLI_VERSION -->3.11.1<!-- /AUTO -->.
+The current documented CLI is <!-- AUTO:CLI_VERSION -->3.11.2<!-- /AUTO -->.
 
 ### 2. Authenticate
 

--- a/docs/sdks/cli.md
+++ b/docs/sdks/cli.md
@@ -12,7 +12,7 @@ Official command-line interface for LanOnasis Memory-as-a-Service.
 npm install -g @lanonasis/cli
 ```
 
-**Current Version:** <!-- AUTO:CLI_VERSION -->3.11.1<!-- /AUTO -->
+**Current Version:** <!-- AUTO:CLI_VERSION -->3.11.2<!-- /AUTO -->
 
 :::info Auth and memory routing
 `lanonasis auth login` currently supports OAuth PKCE, device flow, and API key login. Memory commands target the REST API first and can fall back to direct `/functions/v1/memory-*` routes for compatible bearer-token sessions.


### PR DESCRIPTION
## Summary
Run `node scripts/sync-docs-versions.js` (mutator) against the pinned docs commit.

Bumps `AUTO:CLI_VERSION` markers 3.11.1 → 3.11.2 to match canonical `apps/lanonasis-maas/cli/package.json` (version `3.11.2`), fixing the root monorepo docs CI `check:docs-sync` drift:

- `docs/intro.md`
- `docs/cli/reference.md`
- `docs/sdks/cli.md`

`docs/sdks/typescript.md` (`MEMORY_CLIENT_VERSION` 2.2.1) and `docs/memory/sdk.md` (non-script-managed marker) were already in sync / untouched.

## Verification
`node scripts/sync-docs-versions.js --check` passes.

## Test Plan
- [ ] docs CI `check:docs-sync` green on root repo after pointer bump