### PR TITLE
fix(docs): align tracked Vercel metadata with engines pin (24.x)

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -11,6 +11,6 @@
     "outputDirectory": "build",
     "rootDirectory": ".",
     "directoryListing": false,
-    "nodeVersion": "20.x"
+    "nodeVersion": "24.x"
   }
 }


### PR DESCRIPTION
## Summary

P3 follow-up: PR #31 pinned `package.json` engines to node `24.x` for deterministic Vercel builds, but the tracked `.vercel/project.json` still recorded `nodeVersion: 20.x`. This one-line change aligns the repo-local metadata with the engines contract.

## Scope
- `.vercel/project.json`: `nodeVersion` 20.x → 24.x

No behavior change — Vercel already resolves 24.x via engines. Closes the last repo-side deployment-drift item from audit P3 §6.4. The Vercel dashboard project setting itself remains operator-owned (documented in PR #31 body).