### PR TITLE
docs: add database topology cross-link to Platform sidebar

### DIFF
--- a/docs/platform/topology.md
+++ b/docs/platform/topology.md
@@ -11,13 +11,10 @@ topology-of-record. It answers the recurring operational question — *which
 database is authoritative for which data* — without exposing the connection
 details that live in the private backend repository.
 
-The canonical topology documentation is maintained in the private backend
-engine repo at
-`apps/onasis-core/docs/supabase-api/NEON-EXTRACTION-AND-DB-TOPOLOGY-2026-07-18.md`
-and its companion routing inventory
-`apps/onasis-core/docs/supabase-api/ROUTING_ARCHITECTURE.md`. This page stays in
-sync with those documents; if a statement here disagrees with one of them, the
-private doc wins.
+The canonical topology documentation is maintained in internal operator
+documentation. This page stays in sync with it and contains only the approved
+public summary; if a statement here disagrees with the internal documentation,
+the internal documentation wins.
 
 ## Source-of-truth map
 
@@ -51,6 +48,6 @@ downstream-only. Do not point live writers at the replica.
   and production considerations
 
 > **Operators:** for the full topology-of-record, network attribution notes,
-> migration record, and routing inventory, read the private documents listed at
-> the top of this page. Do not republish their contents (project references,
+> migration record, and routing inventory, read the internal operator
+> documentation. Do not republish its contents (project references,
 > credentials, or internal topology detail) in public-facing material.

--- a/docs/platform/topology.md
+++ b/docs/platform/topology.md
@@ -1,0 +1,56 @@
+---
+title: Database Topology & Data Ownership
+sidebar_label: Database Topology
+description: "Which data domain is authoritative where — the platform database topology-of-record and the public cross-link to the canonical topology docs."
+---
+
+# Database Topology & Data Ownership
+
+This page is the **public-facing summary** of the LanOnasis database
+topology-of-record. It answers the recurring operational question — *which
+database is authoritative for which data* — without exposing the connection
+details that live in the private backend repository.
+
+The canonical topology documentation is maintained in the private backend
+engine repo at
+`apps/onasis-core/docs/supabase-api/NEON-EXTRACTION-AND-DB-TOPOLOGY-2026-07-18.md`
+and its companion routing inventory
+`apps/onasis-core/docs/supabase-api/ROUTING_ARCHITECTURE.md`. This page stays in
+sync with those documents; if a statement here disagrees with one of them, the
+private doc wins.
+
+## Source-of-truth map
+
+| Data domain | Source of truth | Notes |
+| --- | --- | --- |
+| Memory data (MaaS / intelligence) | Primary platform Supabase project | `maas.memory_entries` and related memory/intelligence data live here. The legacy replica never carried live memory data. |
+| `auth_gateway.*` (writers) | Dedicated auth-gateway Supabase project | Authoritative since the 2026-07-18 operator directive. |
+| Outbox / events backup feed | Populated **from** the primary project **into** the emergency replica | Emergency-recovery path only. |
+| Emergency replica | Legacy replica database | Retained as a frozen/downstream emergency recovery path. It is **not** a source of truth for live data. |
+
+## What changed on 2026-07-18
+
+- The auth-gateway project became the **authoritative** store for
+  `auth_gateway.*` and related security data.
+- The legacy replica was demoted to an **emergency / frozen replica** used for
+  recovery feeds only.
+- Memory data was already authoritative in the primary platform project; the
+  replica never carried live memory data.
+
+Operational implication: treat the primary project and the auth-gateway project
+as authoritative for their respective domains, and treat the legacy replica as
+downstream-only. Do not point live writers at the replica.
+
+## Where to go next
+
+- [Platform Architecture & Domains](./architecture.md) — the service-level map
+- [Auth Gateway (Enterprise Identity)](./auth-gateway.md) — identity, sessions,
+  and API-key contexts
+- [Memory Suite Overview](../memory/overview.md) — REST, SDK, and CLI surface
+- [Operating the LanOnasis Platform](../ops/operating-platform.md) — monitoring
+  and production considerations
+
+> **Operators:** for the full topology-of-record, network attribution notes,
+> migration record, and routing inventory, read the private documents listed at
+> the top of this page. Do not republish their contents (project references,
+> credentials, or internal topology detail) in public-facing material.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -144,6 +144,7 @@ const sidebars: SidebarsConfig = {
       label: 'Platform Architecture',
       items: [
         'platform/architecture',
+        'platform/topology',
         'platform/onasis-core',
         'platform/mcp-core',
         'platform/mcp-lanonasis',


### PR DESCRIPTION
Implements \u00a721.7 of DOCS-DRIFT-REVIEW-2026-08-03 (kanban t_80f1beaa).

Operator decision 2026-08-08 (option B): cross-link to the existing post-rewrite topology content as the topology-of-record rather than authoring a new TOPOLOGY.md.

**Changes**
- New `docs/platform/topology.md` (sidebar_label: Database Topology) — public-safe same-page summary of the database topology-of-record, cross-referencing the canonical private onasis-core docs (NEON-EXTRACTION-AND-DB-TOPOLOGY-2026-07-18.md, ROUTING_ARCHITECTURE.md) without leaking project refs or credentials.
- `sidebars.ts`: added `platform/topology` under Platform Architecture, after `platform/architecture`.

**Verification**
- `bun run check:links` — no broken relative links
- `bun run typecheck` — clean
- `bun run check:docs-sync` — fails on pre-existing `static/specs.json` generator drift at submodule HEAD (present before this change; addressed by the open PR #34). This PR intentionally does not touch generated spec manifests.

Related: t_0e09ebe0 (NEON-EXTRACTION fixes, shipped PR #78), t_c3925d2b (ROUTING_ARCHITECTURE rewrite, content on onasis-core HEAD).