### PR TITLE
docs: resolve committed merge conflict in cli/reference.md (CLI 3.11.2)

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -9,15 +9,9 @@ description: "Complete reference for the LanOnasis CLI: commands, options, and e
      to regenerate. CI fails the build if the doc and the CLI disagree
      (`bun run validate:cli-reference`). -->
 
-<<<<<<< HEAD
 ## LanOnasis CLI Reference
 
 Complete reference for the `@lanonasis/cli` v<!-- AUTO:CLI_VERSION -->3.11.2<!-- /AUTO --> — Professional CLI for Memory as a Service (MaaS).
-||||||| 7252389
-Complete reference for the `@lanonasis/cli` v<!-- AUTO:CLI_VERSION -->3.11.1<!-- /AUTO --> - Professional CLI for Memory as a Service (MaaS).
-=======
-Complete reference for the `@lanonasis/cli` v<!-- AUTO:CLI_VERSION -->3.11.2<!-- /AUTO --> - Professional CLI for Memory as a Service (MaaS).
->>>>>>> cdx/docs-version-sync-3.11.2-20260808
 
 ## Installation
 


### PR DESCRIPTION
Fixes docs CI version sync (check:docs-sync) on the current docs main.

## Problem
`d652eba` (cli references update to match live package) carries unresolved three-way merge conflict markers in `docs/cli/reference.md`, left over from the prior `cdx/docs-version-sync-3.11.2` branch merge. As committed, `node scripts/sync-docs-versions.js --check` fails with `Out-of-sync versions in docs/cli/reference.md` because the stale `3.11.1` base/ours variant remains inside the conflict block.

## Change
Resolved the conflict to the HEAD side — single `## LanOnasis CLI Reference` heading + `AUTO:CLI_VERSION` marker `3.11.2` — removing the conflict markers and the `3.11.1` variant. Canonical `apps/lanonasis-maas/cli/package.json` is `3.11.2` (source of truth per sync-docs-versions.js).

## Verification
- `node scripts/sync-docs-versions.js --check` → ✅ Docs version sync complete
- `git grep` for conflict markers in docs/ → none

## Note
Full `check:docs-sync` still fails on the specs manifest (`static/specs.json`) — that is a separate spec drift tracked on follow-up card t_b7ab5767, out of this PR's scope.