### PR TITLE
fix(docs): stabilize OpenAPI sync manifest provenance

### DIFF
--- a/scripts/sync-docs-specs.js
+++ b/scripts/sync-docs-specs.js
@@ -100,9 +100,10 @@ try {
   ensureFile(docsSearchSpecYaml, docsSearchSpec.content, 'Docs Search OpenAPI YAML');
 
   const lastVerified = new Date().toISOString();
-  const memorySourceLabel = fs.existsSync(memorySpecSource)
-    ? 'monorepo:apps/onasis-core/docs/supabase-api/SUPABASE_REST_API_OPENAPI.yaml'
-    : 'committed:static/memory-api.yaml';
+  // Keep the manifest deterministic whether docs runs standalone or inside the
+  // monorepo. The artifact hash, not the checkout layout, is the drift signal.
+  const memorySourceLabel =
+    'canonical:apps/onasis-core/docs/supabase-api/SUPABASE_REST_API_OPENAPI.yaml';
   const docsSourceLabel = 'repo:apps/docs-lanonasis/openapi.yaml';
 
   // Drift-visibility envelope: `last_verified` + `synced_from` make

--- a/static/specs.json
+++ b/static/specs.json
@@ -1,8 +1,8 @@
 {
-  "last_verified": "2026-08-11T19:38:33.324Z",
+  "last_verified": "2026-08-16T15:03:34.938Z",
   "synced_from": {
     "generator": "scripts/sync-docs-specs.js",
-    "memory": "committed:static/memory-api.yaml",
+    "memory": "canonical:apps/onasis-core/docs/supabase-api/SUPABASE_REST_API_OPENAPI.yaml",
     "docs": "repo:apps/docs-lanonasis/openapi.yaml"
   },
   "specs": [
@@ -14,8 +14,8 @@
       "badge": "MCP v2.0 - 31 Tools",
       "version": "1.1.0",
       "hash": "556e97016b996967c02f0fbd20fc54854a22f58c95465baa5bee6251d4efc2c4",
-      "last_verified": "2026-08-11T19:38:33.324Z",
-      "synced_from": "committed:static/memory-api.yaml",
+      "last_verified": "2026-08-16T15:03:34.938Z",
+      "synced_from": "canonical:apps/onasis-core/docs/supabase-api/SUPABASE_REST_API_OPENAPI.yaml",
       "paths": [
         "/memory-api.json",
         "/memory-api.yaml"
@@ -29,7 +29,7 @@
       "badge": "Docs Search API",
       "version": "1.0.0",
       "hash": "ab9e5e986129af6927121eaef768665c86fcc8090976044371f5d1fa9b2b9306",
-      "last_verified": "2026-08-11T19:38:33.324Z",
+      "last_verified": "2026-08-16T15:03:34.938Z",
       "synced_from": "repo:apps/docs-lanonasis/openapi.yaml",
       "paths": [
         "/openapi.json",


### PR DESCRIPTION
Makes `static/specs.json` deterministic whether Docs runs standalone or within the monorepo. The canonical OpenAPI path is now stable; the artifact SHA-256 remains the drift signal.

This fixes root Docs CI rejecting a byte-identical spec solely because the generated provenance label depended on checkout layout.

Validation:
- `bun run sync:docs` and `bun run check:docs-sync` pass inside a monorepo-shaped checkout with Onasis source present;
- same commands pass in a clean standalone Docs checkout with no Onasis source;
- `git diff --check` passes.